### PR TITLE
POFIM-186 Oppretter forespørsler for migrerte saker fra fpsak

### DIFF
--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
@@ -70,7 +70,8 @@ public class ForespørselRest {
                     new AktørIdEntitet(request.aktørId().id()),
                     new OrganisasjonsnummerDto(organisasjonsnummer.orgnr()),
                     request.fagsakSaksnummer(),
-                    request.førsteUttaksdato());
+                    request.førsteUttaksdato(),
+                    request.migrering());
 
                 if (ForespørselResultat.FORESPØRSEL_OPPRETTET.equals(bleForespørselOpprettet)) {
                     MetrikkerTjeneste.loggForespørselOpprettet(KodeverkMapper.mapYtelsetype(request.ytelsetype()));

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRest.java
@@ -64,6 +64,7 @@ public class ForespørselRest {
 
             LOG.info("Mottok forespørsel om inntektsmeldingoppgave på fagsakSaksnummer {} for orgnumrene: {} ", request.fagsakSaksnummer(), request.organisasjonsnumre());
             List<OpprettForespørselResponsNy.OrganisasjonsnummerMedStatus> organisasjonsnumreMedStatus = new ArrayList<>();
+            var migrering = request.migrering();
             request.organisasjonsnumre().forEach(organisasjonsnummer -> {
                 var bleForespørselOpprettet = forespørselBehandlingTjeneste.håndterInnkommendeForespørsel(request.skjæringstidspunkt(),
                     KodeverkMapper.mapYtelsetype(request.ytelsetype()),
@@ -71,10 +72,12 @@ public class ForespørselRest {
                     new OrganisasjonsnummerDto(organisasjonsnummer.orgnr()),
                     request.fagsakSaksnummer(),
                     request.førsteUttaksdato(),
-                    request.migrering());
+                    migrering);
 
                 if (ForespørselResultat.FORESPØRSEL_OPPRETTET.equals(bleForespørselOpprettet)) {
-                    MetrikkerTjeneste.loggForespørselOpprettet(KodeverkMapper.mapYtelsetype(request.ytelsetype()));
+                    if(!migrering) {
+                        MetrikkerTjeneste.loggForespørselOpprettet(KodeverkMapper.mapYtelsetype(request.ytelsetype()));
+                    }
                 }
                 organisasjonsnumreMedStatus.add(new OpprettForespørselResponsNy.OrganisasjonsnummerMedStatus(organisasjonsnummer, bleForespørselOpprettet));
             });

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/OpprettForespørselRequest.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/rest/OpprettForespørselRequest.java
@@ -17,5 +17,6 @@ public record OpprettForespørselRequest(@NotNull @Valid AktørIdDto aktørId,
                                         @NotNull @Valid YtelseTypeDto ytelsetype,
                                         @NotNull @Valid SaksnummerDto fagsakSaksnummer,
                                         @Valid LocalDate førsteUttaksdato,
-                                        @Valid List<OrganisasjonsnummerDto> organisasjonsnumre) {
+                                        @Valid List<OrganisasjonsnummerDto> organisasjonsnumre,
+                                        @Valid boolean migrering) {
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -224,6 +224,10 @@ public class ForespørselBehandlingTjeneste {
         }
 
         forespørselTjeneste.setOppgaveId(uuid, oppgaveId);
+        //Midlertiding løsning for å lukke migrerte forespørsler
+        if (migrering)  {
+            ferdigstillForespørsel(uuid, aktørId, organisasjonsnummer, førsteUttaksdato, LukkeÅrsak.EKSTERN_INNSENDING);
+        }
     }
 
     public UUID opprettForespørselForArbeidsgiverInitiertIm(Ytelsetype ytelsetype,

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -189,7 +189,8 @@ public class ForespørselBehandlingTjeneste {
             merkelapp,
             organisasjonsnummer.orgnr(),
             ForespørselTekster.lagSaksTittel(person.mapFulltNavn(), person.fødselsdato()),
-            skjemaUri);
+            skjemaUri,
+            migrering ? Optional.of(førsteUttaksdato) : Optional.empty());
 
         if (tilleggsinfo != null) {
             arbeidsgiverNotifikasjon.oppdaterSakTilleggsinformasjon(arbeidsgiverNotifikasjonSakId, tilleggsinfo);
@@ -247,7 +248,8 @@ public class ForespørselBehandlingTjeneste {
             merkelapp,
             organisasjonsnummer.orgnr(),
             ForespørselTekster.lagSaksTittel(person.mapFulltNavn(), person.fødselsdato()),
-            skjemaUri);
+            skjemaUri,
+            Optional.empty());
 
         forespørselTjeneste.setArbeidsgiverNotifikasjonSakId(uuid, fagerSakId);
 

--- a/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjeneste.java
@@ -197,17 +197,9 @@ public class ForespørselBehandlingTjeneste {
 
         forespørselTjeneste.setArbeidsgiverNotifikasjonSakId(uuid, arbeidsgiverNotifikasjonSakId);
 
-        String oppgaveId;
+        String oppgaveId = null;
         try {
-            if (migrering) {
-                oppgaveId = arbeidsgiverNotifikasjon.opprettMigrertOppgave(uuid.toString(),
-                    merkelapp,
-                    uuid.toString(),
-                    organisasjonsnummer.orgnr(),
-                    ForespørselTekster.lagOppgaveTekst(ytelsetype),
-                    skjemaUri,
-                    skjæringstidspunkt);
-            } else {
+            if (!migrering) {
                 oppgaveId = arbeidsgiverNotifikasjon.opprettOppgave(uuid.toString(),
                     merkelapp,
                     uuid.toString(),
@@ -223,7 +215,9 @@ public class ForespørselBehandlingTjeneste {
             throw e;
         }
 
-        forespørselTjeneste.setOppgaveId(uuid, oppgaveId);
+        if (oppgaveId != null) {
+            forespørselTjeneste.setOppgaveId(uuid, oppgaveId);
+        }
         //Midlertiding løsning for å lukke migrerte forespørsler
         if (migrering)  {
             ferdigstillForespørsel(uuid, aktørId, organisasjonsnummer, førsteUttaksdato, LukkeÅrsak.EKSTERN_INNSENDING);

--- a/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagDtoTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/imdialog/tjenester/GrunnlagDtoTjeneste.java
@@ -21,6 +21,7 @@ import no.nav.familie.inntektsmelding.metrikker.MetrikkerTjeneste;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.familie.inntektsmelding.forespørsel.modell.ForespørselEntitet;
 import no.nav.familie.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.familie.inntektsmelding.imdialog.rest.InntektsmeldingDialogDto;
 import no.nav.familie.inntektsmelding.imdialog.rest.SlåOppArbeidstakerResponseDto;
@@ -28,6 +29,7 @@ import no.nav.familie.inntektsmelding.integrasjoner.aareg.ArbeidstakerTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.inntektskomponent.InntektTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.organisasjon.OrganisasjonTjeneste;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.familie.inntektsmelding.integrasjoner.person.PersonInfo;
 import no.nav.familie.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.familie.inntektsmelding.koder.ForespørselStatus;
 import no.nav.familie.inntektsmelding.koder.Ytelsetype;

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjon.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjon.java
@@ -35,11 +35,4 @@ public interface ArbeidsgiverNotifikasjon {
                                               String varselTekst,
                                               URI lenke);
 
-    String opprettMigrertOppgave(String string,
-                                 Merkelapp merkelapp,
-                                 String eksternId,
-                                 String organisasjonsnummer,
-                                 String oppgavetekst,
-                                 URI skjemaUri,
-                                 LocalDate skjæringstidsunkt);
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjon.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjon.java
@@ -1,6 +1,7 @@
 package no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon;
 
 import java.net.URI;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 
 public interface ArbeidsgiverNotifikasjon {
@@ -33,4 +34,12 @@ public interface ArbeidsgiverNotifikasjon {
                                               String beskjedTekst,
                                               String varselTekst,
                                               URI lenke);
+
+    String opprettMigrertOppgave(String string,
+                                 Merkelapp merkelapp,
+                                 String eksternId,
+                                 String organisasjonsnummer,
+                                 String oppgavetekst,
+                                 URI skjemaUri,
+                                 LocalDate skjæringstidsunkt);
 }

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjon.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjon.java
@@ -3,10 +3,11 @@ package no.nav.familie.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon;
 import java.net.URI;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.util.Optional;
 
 public interface ArbeidsgiverNotifikasjon {
 
-    String opprettSak(String grupperingsid, Merkelapp merkelapp, String virksomhetsnummer, String saksTittel, URI lenke);
+    String opprettSak(String grupperingsid, Merkelapp merkelapp, String virksomhetsnummer, String saksTittel, URI lenke, Optional<LocalDate> førsteUttaksdato);
 
     String oppdaterSakTilleggsinformasjon(String id, String overstyrtTilleggsinformasjon);
 

--- a/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonTjeneste.java
+++ b/src/main/java/no/nav/familie/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonTjeneste.java
@@ -136,39 +136,6 @@ class ArbeidsgiverNotifikasjonTjeneste implements ArbeidsgiverNotifikasjon {
         return klient.opprettBeskjedOgVarsling(beskjedRequest, projection);
     }
 
-    @Override
-    public String opprettMigrertOppgave(String grupperingsid, Merkelapp merkelapp, String eksternId, String orgnr, String oppgaveTekst, URI oppgaveLenke, LocalDate skjæringstidsunkt) {
-        var request = NyOppgaveMutationRequest.builder()
-            .setNyOppgave(NyOppgaveInput.builder()
-                .setMottaker(lagAltinnMottakerInput())
-                .setNotifikasjon(NotifikasjonInput.builder()
-                    .setMerkelapp(merkelapp.getBeskrivelse())
-                    .setTekst(oppgaveTekst)
-                    .setLenke(oppgaveLenke.toString())
-                    .build())
-                .setMetadata(MetadataInput.builder()
-                    .setVirksomhetsnummer(orgnr)
-                    .setOpprettetTidspunkt(skjæringstidsunkt.minusWeeks(4).atStartOfDay().toString())
-                    .setEksternId(eksternId)
-                    .setGrupperingsid(grupperingsid)
-                    .build())
-                .build())
-            .build();
-
-
-        var projection = new NyOppgaveResultatResponseProjection().typename()
-            .onNyOppgaveVellykket(new NyOppgaveVellykketResponseProjection().id())
-            .onUgyldigMerkelapp(new UgyldigMerkelappResponseProjection().feilmelding())
-            .onUgyldigMottaker(new UgyldigMottakerResponseProjection().feilmelding())
-            .onDuplikatEksternIdOgMerkelapp(new DuplikatEksternIdOgMerkelappResponseProjection().feilmelding())
-            .onUkjentProdusent(new UkjentProdusentResponseProjection().feilmelding())
-            .onUkjentRolle(new UkjentRolleResponseProjection().feilmelding())
-            .onUgyldigPaaminnelseTidspunkt(new UgyldigPaaminnelseTidspunktResponseProjection().feilmelding());
-
-        return klient.opprettOppgave(request, projection);
-
-    }
-
     private static MottakerInput lagAltinnMottakerInput() {
         return MottakerInput.builder()
             .setAltinn(AltinnMottakerInput.builder().setServiceCode(SERVICE_CODE).setServiceEdition(SERVICE_EDITION_CODE).build())

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRestTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/rest/ForespørselRestTest.java
@@ -2,6 +2,7 @@ package no.nav.familie.inntektsmelding.forespørsel.rest;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,14 +54,14 @@ class ForespørselRestTest {
 
         var fagsakSaksnummer = new SaksnummerDto("SAK");
         var response = forespørselRest.opprettForespørsel(
-            new OpprettForespørselRequest(aktørId, null, LocalDate.now(), YtelseTypeDto.FORELDREPENGER, fagsakSaksnummer, LocalDate.now().plusDays(5), List.of(orgnummer)));
+            new OpprettForespørselRequest(aktørId, null, LocalDate.now(), YtelseTypeDto.FORELDREPENGER, fagsakSaksnummer, LocalDate.now().plusDays(5), List.of(orgnummer), false));
 
         var forventetResultat = new OpprettForespørselResponsNy(List.of(new OpprettForespørselResponsNy.OrganisasjonsnummerMedStatus(orgnummer, ForespørselResultat.FORESPØRSEL_OPPRETTET)));
 
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
         assertThat(response.getEntity()).isEqualTo(forventetResultat);
         verify(forespørselBehandlingTjeneste).håndterInnkommendeForespørsel(LocalDate.now(), Ytelsetype.FORELDREPENGER,
-            new AktørIdEntitet(aktørId.id()), orgnummer, fagsakSaksnummer, LocalDate.now().plusDays(5));
+            new AktørIdEntitet(aktørId.id()), orgnummer, fagsakSaksnummer, LocalDate.now().plusDays(5), false);
     }
 
     @Test
@@ -73,7 +74,7 @@ class ForespørselRestTest {
 
         var fagsakSaksnummer = new SaksnummerDto("SAK");
         var response = forespørselRest.opprettForespørsel(
-            new OpprettForespørselRequest(aktørId, null, LocalDate.now(), YtelseTypeDto.FORELDREPENGER, fagsakSaksnummer, LocalDate.now().plusDays(5), List.of(orgnummer, orgnummer2)));
+            new OpprettForespørselRequest(aktørId, null, LocalDate.now(), YtelseTypeDto.FORELDREPENGER, fagsakSaksnummer, LocalDate.now().plusDays(5), List.of(orgnummer, orgnummer2), false));
 
         var forventetResultat = new OpprettForespørselResponsNy(List.of(
             new OpprettForespørselResponsNy.OrganisasjonsnummerMedStatus(orgnummer, ForespørselResultat.FORESPØRSEL_OPPRETTET),
@@ -82,7 +83,7 @@ class ForespørselRestTest {
         assertThat(response.getStatus()).isEqualTo(HttpStatus.OK_200);
         assertThat(response.getEntity()).isEqualTo(forventetResultat);
 
-        verify(forespørselBehandlingTjeneste, times(2)).håndterInnkommendeForespørsel(any(), any(), any(), any(), any(), any());
+        verify(forespørselBehandlingTjeneste, times(2)).håndterInnkommendeForespørsel(any(), any(), any(), any(), any(), any(), anyBoolean());
     }
 
     private void mockForespørsel() {
@@ -91,6 +92,7 @@ class ForespørselRestTest {
             any(),
             any(),
             any(),
-            any())).thenReturn(ForespørselResultat.FORESPØRSEL_OPPRETTET);
+            any(),
+            anyBoolean())).thenReturn(ForespørselResultat.FORESPØRSEL_OPPRETTET);
     }
 }

--- a/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
+++ b/src/test/java/no/nav/familie/inntektsmelding/forespørsel/tjenester/ForespørselBehandlingTjenesteTest.java
@@ -97,7 +97,7 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
     }
 
     @Test
-    void skal_opprette_migrert_oppgave_for_forespørsel() {
+    void skal_sette_migrert_forespørsel_til_ferdig_og_ikke_opprette_oppgave() {
         mockInfoForOpprettelse(AKTØR_ID, YTELSETYPE, BRREG_ORGNUMMER, SAK_ID, OPPGAVE_ID, true);
         when(organisasjonTjeneste.finnOrganisasjon(BRREG_ORGNUMMER)).thenReturn(new Organisasjon("test org", BRREG_ORGNUMMER));
 
@@ -116,7 +116,8 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
         assertThat(resultat).isEqualTo(ForespørselResultat.FORESPØRSEL_OPPRETTET);
         assertThat(lagret).hasSize(1);
         assertThat(lagret.getFirst().getArbeidsgiverNotifikasjonSakId()).isEqualTo(SAK_ID);
-        assertThat(lagret.getFirst().getOppgaveId()).isEqualTo(Optional.of(OPPGAVE_ID));
+        assertThat(lagret.getFirst().getOppgaveId()).isEmpty();
+        assertThat(lagret.getFirst().getStatus()).isEqualTo(ForespørselStatus.FERDIG);
     }
 
     @Test
@@ -565,10 +566,7 @@ class ForespørselBehandlingTjenesteTest extends EntityManagerAwareTest {
 
         lenient().when(personTjeneste.hentPersonInfoFraAktørId(new AktørIdEntitet(aktørId), ytelsetype)).thenReturn(personInfo);
         lenient().when(arbeidsgiverNotifikasjon.opprettSak(any(), any(), eq(brregOrgnummer), eq(sakTittel), any())).thenReturn(sakId);
-        if (migrering) {
-        lenient().when(arbeidsgiverNotifikasjon.opprettMigrertOppgave(any(), any(), any(), eq(brregOrgnummer), any(), any(), any()))
-            .thenReturn(oppgaveId);
-        } else {
+        if (!migrering) {
             lenient().when(arbeidsgiverNotifikasjon.opprettOppgave(any(), any(), any(), eq(brregOrgnummer), any(), any(), any(), any()))
                 .thenReturn(oppgaveId);
         }


### PR DESCRIPTION
Setter ingen varsel eller påminnelse. Setter opprettet tidspunkt på oppgaven til 4 uker før opprinnelige skjæringstidspunkt. Dette for å ikke få sakene først i sakslisten i arbeidsgiverportalen. Dersom arbeidsgiver har vært inne på portalen etter dette tidspunktet vil heller ikke bjella vises.