### PR TITLE
TFP-6940: Legg til InntektsmeldingFilterRequest i kontrakter

### DIFF
--- a/kontrakter/src/main/java/no/nav/foreldrepenger/inntektsmelding/imapi/inntektsmelding/InntektsmeldingFilterRequest.java
+++ b/kontrakter/src/main/java/no/nav/foreldrepenger/inntektsmelding/imapi/inntektsmelding/InntektsmeldingFilterRequest.java
@@ -1,0 +1,19 @@
+package no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import no.nav.foreldrepenger.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.foreldrepenger.inntektsmelding.felles.OrganisasjonsnummerDto;
+import no.nav.foreldrepenger.inntektsmelding.felles.YtelseTypeDto;
+
+public record InntektsmeldingFilterRequest(@NotNull @Valid OrganisasjonsnummerDto orgnr,
+                                           @Valid FødselsnummerDto fnr,
+                                           @Valid YtelseTypeDto ytelseType,
+                                           @Valid UUID forespørselUuid,
+                                           @Valid LocalDate fom,
+                                           @Valid LocalDate tom) {
+}


### PR DESCRIPTION
Legger til ny InntektsmeldingFilterRequest record i kontrakter-modulen for filtrering av inntektsmeldinger. Støtter filtrering på orgnr, fnr, ytelseType, forespørselUuid, fom og tom.