### PR TITLE
TFP-6940: Filter-endepunkt for inntektsmeldinger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>no.nav.foreldrepenger.inntektsmelding</groupId>
             <artifactId>inntektsmelding-kontrakt</artifactId>
-            <version>0.1.4</version>
+            <version>0.1.5</version>
         </dependency>
 
 

--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/imapi/rest/inntektsmelding/InntektsmeldingApiRest.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/imapi/rest/inntektsmelding/InntektsmeldingApiRest.java
@@ -34,14 +34,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.swagger.v3.oas.annotations.Operation;
-import no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingRequest;
-import no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingResponse;
 import no.nav.foreldrepenger.inntektsmelding.imapi.rest.tjenester.InntektsmeldingApiMapper;
 import no.nav.foreldrepenger.inntektsmelding.imapi.rest.tjenester.InntektsmeldingApiMottakTjeneste;
-import no.nav.foreldrepenger.inntektsmelding.imapi.rest.tjenester.InntektsmeldingKontraktMapper;
 import no.nav.foreldrepenger.inntektsmelding.inntektsmelding.InntektsmeldingTjeneste;
-import no.nav.foreldrepenger.inntektsmelding.integrasjoner.person.PersonIdent;
-import no.nav.foreldrepenger.inntektsmelding.integrasjoner.person.PersonTjeneste;
 import no.nav.foreldrepenger.inntektsmelding.server.auth.api.AutentisertMedAzure;
 import no.nav.foreldrepenger.inntektsmelding.server.auth.api.Tilgangskontrollert;
 import no.nav.foreldrepenger.inntektsmelding.server.tilgangsstyring.Tilgang;

--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/imapi/rest/inntektsmelding/InntektsmeldingApiRest.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/imapi/rest/inntektsmelding/InntektsmeldingApiRest.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.inntektsmelding.imapi.rest.inntektsmelding;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -8,6 +9,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
@@ -15,6 +17,18 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
+import no.nav.foreldrepenger.inntektsmelding.felles.YtelseTypeDto;
+import no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding.HentInntektsmeldingResponse;
+import no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding.InntektsmeldingFilterRequest;
+import no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingRequest;
+import no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding.SendInntektsmeldingResponse;
+import no.nav.foreldrepenger.inntektsmelding.imapi.rest.tjenester.InntektsmeldingKontraktMapper;
+import no.nav.foreldrepenger.inntektsmelding.integrasjoner.person.PersonIdent;
+
+import no.nav.foreldrepenger.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.foreldrepenger.inntektsmelding.typer.kodeverk.Ytelsetype;
+import no.nav.foreldrepenger.inntektsmelding.typer.lager.AktørIdEntitet;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -101,5 +115,50 @@ public class InntektsmeldingApiRest {
 
         var mottattInntektsmelding = InntektsmeldingApiMapper.mapTilDto(request, aktørId.get());
         return inntektsmeldingMottakTjeneste.mottaInntektsmelding(mottattInntektsmelding, request.foresporselUuid());
+    }
+
+    @POST
+    @Path("/hent/inntektsmeldinger")
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Operation(description = "Henter inntektsmeldinger basert på filter", tags = "ekstern-api")
+    @Tilgangskontrollert
+    public Response hentInntektsmeldinger(@Valid @NotNull InntektsmeldingFilterRequest filterRequest) {
+        tilgangskontroll.sjekkErSystembruker();
+
+        List<HentInntektsmeldingResponse> responsListe;
+
+        if (filterRequest.forespørselUuid() != null) {
+            responsListe = inntektsmeldingTjeneste.hentInntektsmeldinger(filterRequest.forespørselUuid()).stream()
+                .map(inntektsmeldingKontraktMapper::mapTilKontrakt)
+                .toList();
+        } else {
+            var aktørId = Optional.ofNullable(filterRequest.fnr())
+                .flatMap(fnr -> personTjeneste.finnAktørIdForIdent(new PersonIdent(fnr.fnr())))
+                .map(a -> new AktørIdEntitet(a.getAktørId()))
+                .orElse(null);
+
+            var ytelseType = Optional.ofNullable(filterRequest.ytelseType())
+                .map(InntektsmeldingApiRest::mapYtelseType)
+                .orElse(null);
+
+            responsListe = inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(
+                    filterRequest.orgnr().orgnr(),
+                    aktørId,
+                    ytelseType,
+                    filterRequest.fom(),
+                    filterRequest.tom()).stream()
+                .map(inntektsmeldingKontraktMapper::mapTilKontrakt)
+                .toList();
+        }
+
+        return Response.ok(responsListe).build();
+    }
+
+    private static Ytelsetype mapYtelseType(YtelseTypeDto ytelseType) {
+        return switch (ytelseType) {
+            case FORELDREPENGER -> Ytelsetype.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> Ytelsetype.SVANGERSKAPSPENGER;
+        };
     }
 }

--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/inntektsmelding/InntektsmeldingTjeneste.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/inntektsmelding/InntektsmeldingTjeneste.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.inntektsmelding.inntektsmelding;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -9,6 +10,7 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.inntektsmelding.forespørsel.tjenester.ForespørselBehandlingTjeneste;
 import no.nav.foreldrepenger.inntektsmelding.inntektsmelding.lager.InntektsmeldingRepository;
+import no.nav.foreldrepenger.inntektsmelding.typer.kodeverk.Ytelsetype;
 import no.nav.foreldrepenger.inntektsmelding.typer.lager.AktørIdEntitet;
 
 @Dependent
@@ -55,6 +57,17 @@ public class InntektsmeldingTjeneste {
 
     public Long lagreInntektsmelding(InntektsmeldingDto inntektsmeldingDto) {
         return inntektsmeldingRepository.lagreInntektsmelding(InntektsmeldingDtoMapper.mapTilEntitet(inntektsmeldingDto));
+    }
+
+    public List<InntektsmeldingDto> hentInntektsmeldingerFraFilter(String orgnr,
+                                                                    AktørIdEntitet aktørId,
+                                                                    Ytelsetype ytelseType,
+                                                                    LocalDate fom,
+                                                                    LocalDate tom) {
+        return inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, aktørId, ytelseType, fom, tom)
+            .stream()
+            .map(InntektsmeldingDtoMapper::mapFraEntitet)
+            .toList();
     }
 
 }

--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/inntektsmelding/lager/InntektsmeldingRepository.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/inntektsmelding/lager/InntektsmeldingRepository.java
@@ -1,19 +1,27 @@
 package no.nav.foreldrepenger.inntektsmelding.inntektsmelding.lager;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.Predicate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.inntektsmelding.typer.kodeverk.Ytelsetype;
 import no.nav.foreldrepenger.inntektsmelding.typer.lager.AktørIdEntitet;
 
 @Dependent
 public class InntektsmeldingRepository {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InntektsmeldingRepository.class);
 
     private EntityManager entityManager;
 
@@ -58,5 +66,44 @@ public class InntektsmeldingRepository {
 
     public InntektsmeldingEntitet hent(long inntektsmeldingId) {
         return entityManager.find(InntektsmeldingEntitet.class, inntektsmeldingId);
+    }
+
+    public List<InntektsmeldingEntitet> hentInntektsmeldingerFraFilter(String orgnr,
+                                                                       AktørIdEntitet aktørId,
+                                                                       Ytelsetype ytelseType,
+                                                                       LocalDate fom,
+                                                                       LocalDate tom) {
+        var cb = entityManager.getCriteriaBuilder();
+        var cq = cb.createQuery(InntektsmeldingEntitet.class);
+        var root = cq.from(InntektsmeldingEntitet.class);
+
+        var predicates = new ArrayList<Predicate>();
+
+        predicates.add(cb.equal(root.get("arbeidsgiverIdent"), Objects.requireNonNull(orgnr)));
+        if (aktørId != null) {
+            predicates.add(cb.equal(root.get("aktørId"), aktørId));
+        }
+        if (ytelseType != null) {
+            predicates.add(cb.equal(root.get("ytelsetype"), ytelseType));
+        }
+        if (fom != null) {
+            predicates.add(cb.greaterThanOrEqualTo(root.get("opprettetTidspunkt"), fom.atStartOfDay()));
+        }
+        if (tom != null) {
+            predicates.add(cb.lessThan(root.get("opprettetTidspunkt"), tom.plusDays(1).atStartOfDay()));
+        }
+        cq.where(predicates.toArray(new Predicate[0]));
+
+        cq.orderBy(cb.desc(root.get("opprettetTidspunkt")));
+        var query = entityManager.createQuery(cq);
+        query.setMaxResults(1001);
+        var result = query.getResultList();
+        if (result.size() == 1001) {
+            LOG.warn("Hentet 1000 inntektsmeldinger for orgnr {}, men det finnes flere som ikke er hentet ut", orgnr);
+            var redusertListe = new ArrayList<>(result);
+            redusertListe.removeLast();
+            return redusertListe;
+        }
+        return result;
     }
 }

--- a/src/test/java/no/nav/foreldrepenger/inntektsmelding/imapi/rest/inntektsmelding/InntektsmeldingApiRestTest.java
+++ b/src/test/java/no/nav/foreldrepenger/inntektsmelding/imapi/rest/inntektsmelding/InntektsmeldingApiRestTest.java
@@ -213,7 +213,7 @@ class InntektsmeldingApiRestTest {
         var dto = lagInntektsmeldingDto();
         var response = lagHentResponse(UUID.randomUUID());
         when(inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(
-            eq(ORGNR), eq(new AktørIdEntitet(AKTØR_ID)), eq(Ytelsetype.FORELDREPENGER), eq(fom), eq(tom)))
+            ORGNR, new AktørIdEntitet(AKTØR_ID), Ytelsetype.FORELDREPENGER, fom, tom))
             .thenReturn(List.of(dto));
         when(inntektsmeldingKontraktMapper.mapTilKontrakt(dto)).thenReturn(response);
 

--- a/src/test/java/no/nav/foreldrepenger/inntektsmelding/imapi/rest/inntektsmelding/InntektsmeldingApiRestTest.java
+++ b/src/test/java/no/nav/foreldrepenger/inntektsmelding/imapi/rest/inntektsmelding/InntektsmeldingApiRestTest.java
@@ -1,0 +1,288 @@
+package no.nav.foreldrepenger.inntektsmelding.imapi.rest.inntektsmelding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.foreldrepenger.inntektsmelding.felles.FødselsnummerDto;
+import no.nav.foreldrepenger.inntektsmelding.felles.OrganisasjonsnummerDto;
+import no.nav.foreldrepenger.inntektsmelding.felles.YtelseTypeDto;
+import no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding.HentInntektsmeldingResponse;
+import no.nav.foreldrepenger.inntektsmelding.imapi.inntektsmelding.InntektsmeldingFilterRequest;
+import no.nav.foreldrepenger.inntektsmelding.imapi.rest.tjenester.InntektsmeldingApiMottakTjeneste;
+import no.nav.foreldrepenger.inntektsmelding.imapi.rest.tjenester.InntektsmeldingKontraktMapper;
+import no.nav.foreldrepenger.inntektsmelding.integrasjoner.person.AktørId;
+import no.nav.foreldrepenger.inntektsmelding.integrasjoner.person.PersonIdent;
+import no.nav.foreldrepenger.inntektsmelding.integrasjoner.person.PersonTjeneste;
+import no.nav.foreldrepenger.inntektsmelding.inntektsmelding.InntektsmeldingDto;
+import no.nav.foreldrepenger.inntektsmelding.inntektsmelding.InntektsmeldingTjeneste;
+import no.nav.foreldrepenger.inntektsmelding.typer.domene.Arbeidsgiver;
+import no.nav.foreldrepenger.inntektsmelding.server.tilgangsstyring.Tilgang;
+import no.nav.foreldrepenger.inntektsmelding.typer.kodeverk.Ytelsetype;
+import no.nav.foreldrepenger.inntektsmelding.typer.lager.AktørIdEntitet;
+
+@ExtendWith(MockitoExtension.class)
+class InntektsmeldingApiRestTest {
+
+    private static final String ORGNR = "974760673";
+    private static final String FNR = "11111111111";
+    private static final String AKTØR_ID = "1234567890123";
+
+    private InntektsmeldingApiRest inntektsmeldingApiRest;
+
+    @Mock
+    private InntektsmeldingTjeneste inntektsmeldingTjeneste;
+    @Mock
+    private InntektsmeldingApiMottakTjeneste inntektsmeldingMottakTjeneste;
+    @Mock
+    private PersonTjeneste personTjeneste;
+    @Mock
+    private Tilgang tilgang;
+    @Mock
+    private InntektsmeldingKontraktMapper inntektsmeldingKontraktMapper;
+
+    @BeforeEach
+    void setUp() {
+        inntektsmeldingApiRest = new InntektsmeldingApiRest(
+            inntektsmeldingTjeneste,
+            inntektsmeldingMottakTjeneste,
+            personTjeneste,
+            tilgang,
+            inntektsmeldingKontraktMapper
+        );
+    }
+
+    @Test
+    void skal_hente_inntektsmelding_med_uuid() {
+        var uuid = UUID.randomUUID();
+        var dto = lagInntektsmeldingDto();
+        var response = lagHentResponse(uuid);
+
+        when(inntektsmeldingTjeneste.hentInntektsmelding(uuid)).thenReturn(dto);
+        when(inntektsmeldingKontraktMapper.mapTilKontrakt(dto)).thenReturn(response);
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmelding(uuid);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        assertThat(resultat.getEntity()).isEqualTo(response);
+        verify(tilgang).sjekkErSystembruker();
+    }
+
+
+    @Test
+    void skal_hente_inntektsmeldinger_med_forespørselUuid() {
+        var forespørselUuid = UUID.randomUUID();
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), null, null, forespørselUuid, null, null);
+
+        var dto = lagInntektsmeldingDto();
+        var response = lagHentResponse(UUID.randomUUID());
+
+        when(inntektsmeldingTjeneste.hentInntektsmeldinger(forespørselUuid)).thenReturn(List.of(dto));
+        when(inntektsmeldingKontraktMapper.mapTilKontrakt(dto)).thenReturn(response);
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        @SuppressWarnings("unchecked")
+        var liste = (List<HentInntektsmeldingResponse>) resultat.getEntity();
+        assertThat(liste).hasSize(1).containsExactly(response);
+        verify(inntektsmeldingTjeneste).hentInntektsmeldinger(forespørselUuid);
+        verifyNoInteractions(personTjeneste);
+    }
+
+    @Test
+    void skal_hente_inntektsmeldinger_med_kun_orgnr() {
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), null, null, null, null, null);
+
+        when(inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(eq(ORGNR), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(Collections.emptyList());
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        @SuppressWarnings("unchecked")
+        var liste = (List<HentInntektsmeldingResponse>) resultat.getEntity();
+        assertThat(liste).isEmpty();
+        verify(tilgang).sjekkErSystembruker();
+    }
+
+    @Test
+    void skal_hente_inntektsmeldinger_med_orgnr_og_fnr() {
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), new FødselsnummerDto(FNR), null, null, null, null);
+
+        var aktørId = new AktørId(AKTØR_ID);
+        when(personTjeneste.finnAktørIdForIdent(any(PersonIdent.class))).thenReturn(Optional.of(aktørId));
+
+        var dto = lagInntektsmeldingDto();
+        var response = lagHentResponse(UUID.randomUUID());
+
+        when(inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(
+            eq(ORGNR), eq(new AktørIdEntitet(AKTØR_ID)), isNull(), isNull(), isNull()))
+            .thenReturn(List.of(dto));
+        when(inntektsmeldingKontraktMapper.mapTilKontrakt(dto)).thenReturn(response);
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        @SuppressWarnings("unchecked")
+        var liste = (List<HentInntektsmeldingResponse>) resultat.getEntity();
+        assertThat(liste).hasSize(1);
+    }
+
+    @Test
+    void skal_hente_inntektsmeldinger_med_orgnr_og_ytelsetype() {
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), null, YtelseTypeDto.FORELDREPENGER, null, null, null);
+
+        when(inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(
+            eq(ORGNR), isNull(), eq(Ytelsetype.FORELDREPENGER), isNull(), isNull()))
+            .thenReturn(Collections.emptyList());
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        verify(inntektsmeldingTjeneste).hentInntektsmeldingerFraFilter(
+            eq(ORGNR), isNull(), eq(Ytelsetype.FORELDREPENGER), isNull(), isNull());
+    }
+
+    @Test
+    void skal_mappe_svangerskapspenger_ytelsetype_korrekt() {
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), null, YtelseTypeDto.SVANGERSKAPSPENGER, null, null, null);
+
+        when(inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(
+            eq(ORGNR), isNull(), eq(Ytelsetype.SVANGERSKAPSPENGER), isNull(), isNull()))
+            .thenReturn(Collections.emptyList());
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        verify(inntektsmeldingTjeneste).hentInntektsmeldingerFraFilter(
+            eq(ORGNR), isNull(), eq(Ytelsetype.SVANGERSKAPSPENGER), isNull(), isNull());
+    }
+
+    @Test
+    void skal_hente_inntektsmeldinger_med_datofilter() {
+        var fom = LocalDate.of(2025, 1, 1);
+        var tom = LocalDate.of(2025, 12, 31);
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), null, null, null, fom, tom);
+
+        when(inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(eq(ORGNR), isNull(), isNull(), eq(fom), eq(tom)))
+            .thenReturn(Collections.emptyList());
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        verify(inntektsmeldingTjeneste).hentInntektsmeldingerFraFilter(ORGNR, null, null, fom, tom);
+    }
+
+    @Test
+    void skal_hente_med_alle_filterparametre() {
+        var fom = LocalDate.of(2025, 3, 1);
+        var tom = LocalDate.of(2025, 6, 30);
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), new FødselsnummerDto(FNR),
+            YtelseTypeDto.FORELDREPENGER, null, fom, tom);
+
+        var aktørId = new AktørId(AKTØR_ID);
+        when(personTjeneste.finnAktørIdForIdent(any(PersonIdent.class))).thenReturn(Optional.of(aktørId));
+
+        var dto = lagInntektsmeldingDto();
+        var response = lagHentResponse(UUID.randomUUID());
+        when(inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(
+            eq(ORGNR), eq(new AktørIdEntitet(AKTØR_ID)), eq(Ytelsetype.FORELDREPENGER), eq(fom), eq(tom)))
+            .thenReturn(List.of(dto));
+        when(inntektsmeldingKontraktMapper.mapTilKontrakt(dto)).thenReturn(response);
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        @SuppressWarnings("unchecked")
+        var liste = (List<HentInntektsmeldingResponse>) resultat.getEntity();
+        assertThat(liste).hasSize(1).containsExactly(response);
+    }
+
+    @Test
+    void skal_sende_null_aktørId_når_fnr_ikke_finnes_i_pdl() {
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), new FødselsnummerDto(FNR), null, null, null, null);
+
+        when(personTjeneste.finnAktørIdForIdent(any(PersonIdent.class))).thenReturn(Optional.empty());
+        when(inntektsmeldingTjeneste.hentInntektsmeldingerFraFilter(eq(ORGNR), isNull(), isNull(), isNull(), isNull()))
+            .thenReturn(Collections.emptyList());
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        verify(inntektsmeldingTjeneste).hentInntektsmeldingerFraFilter(eq(ORGNR), isNull(), isNull(), isNull(), isNull());
+    }
+
+    @Test
+    void skal_prioritere_forespørselUuid_over_andre_filtre() {
+        var forespørselUuid = UUID.randomUUID();
+        var filter = new InntektsmeldingFilterRequest(
+            new OrganisasjonsnummerDto(ORGNR), new FødselsnummerDto(FNR),
+            YtelseTypeDto.FORELDREPENGER, forespørselUuid,
+            LocalDate.of(2025, 1, 1), LocalDate.of(2025, 12, 31));
+
+        when(inntektsmeldingTjeneste.hentInntektsmeldinger(forespørselUuid)).thenReturn(Collections.emptyList());
+
+        var resultat = inntektsmeldingApiRest.hentInntektsmeldinger(filter);
+
+        assertThat(resultat.getStatus()).isEqualTo(HttpStatus.OK_200);
+        verify(inntektsmeldingTjeneste).hentInntektsmeldinger(forespørselUuid);
+        verifyNoInteractions(personTjeneste);
+    }
+
+    // ---- Hjelpemetoder ----
+
+    private InntektsmeldingDto lagInntektsmeldingDto() {
+        return InntektsmeldingDto.builder()
+            .medInntektsmeldingUuid(UUID.randomUUID())
+            .medArbeidsgiver(new Arbeidsgiver(ORGNR))
+            .medStartdato(LocalDate.now())
+            .medInntekt(BigDecimal.valueOf(50000))
+            .medInnsendtTidspunkt(LocalDateTime.now())
+            .medYtelse(Ytelsetype.FORELDREPENGER)
+            .build();
+    }
+
+    private HentInntektsmeldingResponse lagHentResponse(UUID uuid) {
+        return new HentInntektsmeldingResponse(
+            uuid, UUID.randomUUID(),
+            new FødselsnummerDto(FNR),
+            YtelseTypeDto.FORELDREPENGER,
+            new OrganisasjonsnummerDto(ORGNR),
+            null, LocalDate.now(),
+            BigDecimal.valueOf(50000),
+            LocalDateTime.now(),
+            null, null, null,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+    }
+}

--- a/src/test/java/no/nav/foreldrepenger/inntektsmelding/inntektsmelding/lager/InntektsmeldingRepositoryTest.java
+++ b/src/test/java/no/nav/foreldrepenger/inntektsmelding/inntektsmelding/lager/InntektsmeldingRepositoryTest.java
@@ -303,13 +303,11 @@ class InntektsmeldingRepositoryTest extends EntityManagerAwareTest {
     @Test
     void skal_filtrere_på_orgnr_og_aktørId() {
         var orgnr = "999999999";
-        var aktørId1 = new AktørIdEntitet("9999999999999");
-        var aktørId2 = new AktørIdEntitet("8888888888888");
         lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.FORELDREPENGER);
         lagreInntektsmelding("8888888888888", orgnr, Ytelsetype.FORELDREPENGER);
         lagreInntektsmelding("8888888888888", orgnr, Ytelsetype.SVANGERSKAPSPENGER);
 
-        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, aktørId2, null, null, null);
+        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, new AktørIdEntitet("8888888888888"), null, null, null);
 
         assertThat(resultat).hasSize(2);
     }

--- a/src/test/java/no/nav/foreldrepenger/inntektsmelding/inntektsmelding/lager/InntektsmeldingRepositoryTest.java
+++ b/src/test/java/no/nav/foreldrepenger/inntektsmelding/inntektsmelding/lager/InntektsmeldingRepositoryTest.java
@@ -275,4 +275,115 @@ class InntektsmeldingRepositoryTest extends EntityManagerAwareTest {
         assertThat(etterLagring).isPresent();
     }
 
+    @Test
+    void skal_filtrere_kun_på_orgnr() {
+        var orgnr = "999999999";
+        var annetOrgnr = "888888888";
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.FORELDREPENGER);
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.SVANGERSKAPSPENGER);
+        lagreInntektsmelding("9999999999999", annetOrgnr, Ytelsetype.FORELDREPENGER);
+
+        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, null, null, null, null);
+
+        assertThat(resultat).hasSize(2);
+    }
+
+    @Test
+    void skal_filtrere_på_orgnr_og_ytelsetype() {
+        var orgnr = "999999999";
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.FORELDREPENGER);
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.SVANGERSKAPSPENGER);
+
+        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, null, Ytelsetype.SVANGERSKAPSPENGER, null, null);
+
+        assertThat(resultat).hasSize(1);
+        assertThat(resultat.getFirst().getYtelsetype()).isEqualTo(Ytelsetype.SVANGERSKAPSPENGER);
+    }
+
+    @Test
+    void skal_filtrere_på_orgnr_og_aktørId() {
+        var orgnr = "999999999";
+        var aktørId1 = new AktørIdEntitet("9999999999999");
+        var aktørId2 = new AktørIdEntitet("8888888888888");
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.FORELDREPENGER);
+        lagreInntektsmelding("8888888888888", orgnr, Ytelsetype.FORELDREPENGER);
+        lagreInntektsmelding("8888888888888", orgnr, Ytelsetype.SVANGERSKAPSPENGER);
+
+        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, aktørId2, null, null, null);
+
+        assertThat(resultat).hasSize(2);
+    }
+
+    @Test
+    void skal_filtrere_på_datointerval() {
+        var orgnr = "999999999";
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.FORELDREPENGER);
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.SVANGERSKAPSPENGER);
+
+        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, null, null,
+            Tid.TIDENES_BEGYNNELSE, Tid.TIDENES_ENDE);
+
+        assertThat(resultat).hasSize(2);
+    }
+
+    @Test
+    void skal_returnere_tomt_når_datointerval_ikke_treffer() {
+        var orgnr = "999999999";
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.FORELDREPENGER);
+
+        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, null, null,
+            LocalDate.now().plusDays(7), Tid.TIDENES_ENDE);
+
+        assertThat(resultat).isEmpty();
+    }
+
+    @Test
+    void skal_filtrere_med_kun_fom_dato() {
+        var orgnr = "999999999";
+        lagreInntektsmelding("9999999999999", orgnr, Ytelsetype.FORELDREPENGER);
+
+        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, null, null,
+            Tid.TIDENES_BEGYNNELSE, null);
+
+        assertThat(resultat).hasSize(1);
+    }
+
+    @Test
+    void skal_sortere_nyeste_først() {
+        var orgnr = "999999999";
+        var im1 = lagInntektsmeldingEntitet("9999999999999", orgnr, Ytelsetype.FORELDREPENGER, LocalDateTime.now().minusDays(2));
+        var im2 = lagInntektsmeldingEntitet("9999999999999", orgnr, Ytelsetype.FORELDREPENGER, LocalDateTime.now());
+        inntektsmeldingRepository.lagreInntektsmelding(im1);
+        inntektsmeldingRepository.lagreInntektsmelding(im2);
+
+        var resultat = inntektsmeldingRepository.hentInntektsmeldingerFraFilter(orgnr, null, null, null, null);
+
+        assertThat(resultat).hasSize(2);
+        assertThat(resultat.getFirst().getOpprettetTidspunkt()).isAfter(resultat.getLast().getOpprettetTidspunkt());
+    }
+
+    private void lagreInntektsmelding(String aktørId, String orgnr, Ytelsetype ytelsetype) {
+        var entitet = InntektsmeldingEntitet.builder()
+            .medAktørId(new AktørIdEntitet(aktørId))
+            .medKontaktperson(new KontaktpersonEntitet("Test", "999999999"))
+            .medYtelsetype(ytelsetype)
+            .medMånedInntekt(BigDecimal.valueOf(4000))
+            .medStartDato(LocalDate.now())
+            .medArbeidsgiverIdent(orgnr)
+            .build();
+        inntektsmeldingRepository.lagreInntektsmelding(entitet);
+    }
+
+    private InntektsmeldingEntitet lagInntektsmeldingEntitet(String aktørId, String orgnr, Ytelsetype ytelsetype, LocalDateTime opprettetTidspunkt) {
+        return InntektsmeldingEntitet.builder()
+            .medAktørId(new AktørIdEntitet(aktørId))
+            .medKontaktperson(new KontaktpersonEntitet("Test", "999999999"))
+            .medYtelsetype(ytelsetype)
+            .medMånedInntekt(BigDecimal.valueOf(4000))
+            .medStartDato(LocalDate.now())
+            .medArbeidsgiverIdent(orgnr)
+            .medOpprettetTidspunkt(opprettetTidspunkt)
+            .build();
+    }
+
 }


### PR DESCRIPTION
Legger til nytt POST-endepunkt `/hent/inntektsmeldinger` i InntektsmeldingApiRest for filtrering av inntektsmeldinger.

Endringer:
- Nytt filter-endepunkt med støtte for orgnr, fnr, ytelseType, forespørselUuid, fom og tom
- Ny `hentInntektsmeldingerFraFilter` i InntektsmeldingRepository (CriteriaBuilder)
- Delegering via InntektsmeldingTjeneste
- 7 tester for repository-laget
- Bumper kontrakter-avhengighet til 0.1.5

Avhenger av #272 (kontrakter-endring)