### PR TITLE
Teknisk: Egen rest-app for forespørsler fra fp-backend-apps

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/server/JettyServer.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/server/JettyServer.java
@@ -27,6 +27,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
 import no.nav.foreldrepenger.inntektsmelding.server.app.api.ApiConfig;
+import no.nav.foreldrepenger.inntektsmelding.server.app.api.BackendApiConfig;
 import no.nav.foreldrepenger.inntektsmelding.server.app.forvaltning.ForvaltningApiConfig;
 import no.nav.foreldrepenger.inntektsmelding.server.app.internal.InternalApiConfig;
 import no.nav.foreldrepenger.konfig.Environment;
@@ -115,7 +116,8 @@ public class JettyServer {
             registerDefaultServlet(context);
             registerServlet(context, 0, InternalApiConfig.API_URI, InternalApiConfig.class);
             registerServlet(context, 1, ApiConfig.API_URI, ApiConfig.class);
-            registerServlet(context, 2, ForvaltningApiConfig.API_URI, ForvaltningApiConfig.class);
+            registerServlet(context, 2, BackendApiConfig.API_URI, BackendApiConfig.class);
+            registerServlet(context, 3, ForvaltningApiConfig.API_URI, ForvaltningApiConfig.class);
 
             // Starter tjenester
             context.addEventListener(new ServiceStarterListener());
@@ -153,6 +155,7 @@ public class JettyServer {
         handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, InternalApiConfig.API_URI + "/*"));
         // Slipp gjennom til autentisering i JaxRs / auth-filter
         handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, ApiConfig.API_URI + "/*"));
+        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, BackendApiConfig.API_URI + "/*"));
         handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, ForvaltningApiConfig.API_URI + "/*"));
         // Alt annet av paths og metoder forbudt - 403
         handler.addConstraintMapping(pathConstraint(Constraint.FORBIDDEN, "/*"));

--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/server/app/api/BackendApiConfig.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/server/app/api/BackendApiConfig.java
@@ -15,34 +15,24 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.inntektsmelding.forespørsel.rest.ForespørselRest;
 import no.nav.foreldrepenger.inntektsmelding.imapi.rest.forespørsel.ForespørselApiRest;
 import no.nav.foreldrepenger.inntektsmelding.imapi.rest.inntektsmelding.InntektsmeldingApiRest;
-import no.nav.foreldrepenger.inntektsmelding.imdialog.rest.InntektsmeldingDialogRest;
-import no.nav.foreldrepenger.inntektsmelding.imdialog.rest.aginitiert.ArbeidsgiverinitiertDialogRest;
-import no.nav.foreldrepenger.inntektsmelding.imdialog.rest.kvittering.PdfDokumentRest;
 import no.nav.foreldrepenger.inntektsmelding.overstyring.rest.InntektsmeldingFpsakRest;
 import no.nav.foreldrepenger.inntektsmelding.server.auth.AutentiseringAnnoteringFilter;
-import no.nav.foreldrepenger.inntektsmelding.server.exceptions.LokalRestExceptionMapper;
-import no.nav.vedtak.server.rest.AuthenticationFilter;
-import no.nav.vedtak.server.rest.ValidationExceptionMapper;
-import no.nav.vedtak.server.rest.jackson.Jackson2MapperFeature;
+import no.nav.vedtak.server.rest.FpRestJackson2Feature;
 
 /**
- * For kall fra fp-inntektsmelding-frontend med kontekst EksternBruker og TokenX
- * TODO: Skille rest-klassene fra de som brukes fra backend-api etter omlegging
+ * For kall fra fpsak, fp-inntektsmelding-api, mv med kontekst systembruker eller internbruker
+ * TODO: Skille rest-klassene fra frontend-api og legge på BeskyttetRessurs.
  */
-@ApplicationPath(ApiConfig.API_URI)
-public class ApiConfig extends ResourceConfig {
+@ApplicationPath(BackendApiConfig.API_URI)
+public class BackendApiConfig extends ResourceConfig {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ApiConfig.class);
-    public static final String API_URI = "/api";
+    private static final Logger LOG = LoggerFactory.getLogger(BackendApiConfig.class);
+    public static final String API_URI = "/backend/api";
 
-    public ApiConfig() {
+    public BackendApiConfig() {
         LOG.info("Initialiserer: {}", API_URI);
-        // TODO gjennomgå behov for LokalRestExceptionMapper - frontend bruker ikke feilmelding.
-        register(AuthenticationFilter.class);
-        register(Jackson2MapperFeature.class);
-        register(ValidationExceptionMapper.class);
-        register(LokalRestExceptionMapper.class);
-        // Sikkerhet - lokal "tilleggsautentisering" sjekker match IdentType og Annotering
+        register(FpRestJackson2Feature.class);
+        // Sikkerhet - lokal autentisering - kan antagelig saneres gitt import av abac/BeskyttetRessurs
         register(AutentiseringAnnoteringFilter.class);
 
         // REST
@@ -54,10 +44,7 @@ public class ApiConfig extends ResourceConfig {
 
     private Set<Class<?>> getApplicationClasses() {
         return Set.of(ForespørselRest.class,
-            InntektsmeldingDialogRest.class,
             InntektsmeldingFpsakRest.class,
-            ArbeidsgiverinitiertDialogRest.class,
-            PdfDokumentRest.class,
             ForespørselApiRest.class,
             InntektsmeldingApiRest.class);
     }


### PR DESCRIPTION
Gjøres for å skille audiences slik at det som server frontend skilles fra det som server fpsak/api/...
Det er ulike autentiseringsregimer her og en del ulike rettigheter - så en bedre sikkerhetshistorie å skille disse. 
* Legge om fpsak og im-api mfl til å legge på /backend før /api i path.
* Skille evt RestTjeneste som brukes av både frontend og backend i ulike RestTjeneste
* Fjerne duplikate RestTjeneste - hver skal bare være i 1 ApiConfig.

Trenger en korrektur-sjekk på at jeg har med nok RestTjeneste i BackendApiConfig