### PR TITLE
FIX: Bytt .header() med .setAndReplaceHeader() i FpDokgenRestKlient

### DIFF
--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/integrasjoner/dokgen/v1/FpDokgenRestKlient.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/integrasjoner/dokgen/v1/FpDokgenRestKlient.java
@@ -35,7 +35,7 @@ public class FpDokgenRestKlient {
         var endpoint = UriBuilder.fromUri(restConfig.fpContextPath()).path(API_PATH).path("/v1/dokument/generer/pdf").build();
 
         var request = RestRequest.newPOSTJson(requestDto, endpoint, restConfig)
-            .header(HttpHeaders.ACCEPT, "application/pdf");
+            .setAndReplaceHeader(HttpHeaders.ACCEPT, "application/pdf");
 
         var pdf = restClient.sendReturnByteArray(request);
 


### PR DESCRIPTION
HttpRequest er allerede bygget når .header() kalles, noe som kaster IllegalStateException. Bruker setAndReplaceHeader() i stedet, som fungerer på et ferdigbygd request. Feil funnet i loggovervåking.