### PR TITLE
Teknisk: Bruk fp-graphql framfor ikke-vedlikeholdt verktøy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <felles.version>7.8.2</felles.version>
         <prosesstask.version>5.2.6</prosesstask.version>
         <fp-kontrakter.version>9.4.33</fp-kontrakter.version>
+        <fp-graphql.version>1.0.0</fp-graphql.version>
     </properties>
 
     <dependencyManagement>
@@ -72,6 +73,11 @@
         <dependency>
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
             <artifactId>felles-integrasjon-rest-klient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.graphql</groupId>
+            <artifactId>graphql-runtime</artifactId>
+            <version>${fp-graphql.version}</version>
         </dependency>
         <dependency>
             <groupId>no.nav.foreldrepenger.felles.integrasjon</groupId>
@@ -236,9 +242,9 @@
         <finalName>app</finalName>
         <plugins>
             <plugin>
-                <groupId>io.github.kobylynskyi</groupId>
-                <artifactId>graphql-codegen-maven-plugin</artifactId>
-                <version>5.10.0</version>
+                <groupId>no.nav.foreldrepenger.graphql</groupId>
+                <artifactId>graphql-maven-plugin</artifactId>
+                <version>${fp-graphql.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -248,14 +254,7 @@
                             <graphqlSchemaPaths>${project.basedir}/src/main/resources/graphql/produsent.graphql</graphqlSchemaPaths>
                             <outputDir>${project.build.directory}/generated-sources/client-arbeidsgiver-notifikasjon</outputDir>
                             <modelPackageName>no.nav.foreldrepenger.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon</modelPackageName>
-                            <generateClient>true</generateClient>
-                            <generateApis>false</generateApis>
                             <generateBuilder>true</generateBuilder>
-                            <generateToString>true</generateToString>
-                            <generateParameterizedFieldsResolvers>false</generateParameterizedFieldsResolvers>
-                            <addGeneratedAnnotation>true</addGeneratedAnnotation>
-                            <generatedAnnotation>jakarta.annotation.Generated</generatedAnnotation>
-                            <modelValidationAnnotation>@jakarta.validation.constraints.NotNull</modelValidationAnnotation>
                             <generateJacksonTypeIdResolver>true</generateJacksonTypeIdResolver>
                         </configuration>
                     </execution>
@@ -312,4 +311,10 @@
             <url>https://maven.pkg.github.com/navikt/fp-felles</url> <!-- Samme url som brukes i dependabot.yml -->
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>github</id> <!-- OBS: Brukes også av fp-gha-workflows for action/setup-java -->
+            <url>https://maven.pkg.github.com/navikt/fp-graphql</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonErrorHandler.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/ArbeidsgiverNotifikasjonErrorHandler.java
@@ -5,7 +5,7 @@ import static java.util.stream.Collectors.joining;
 import java.net.URI;
 import java.util.List;
 
-import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLError;
+import no.nav.foreldrepenger.graphql.GraphQLError;
 
 import no.nav.vedtak.exception.TekniskException;
 
@@ -15,7 +15,7 @@ class ArbeidsgiverNotifikasjonErrorHandler {
     }
 
     public static <T> T handleError(List<GraphQLError> errors, URI uri, String kode) {
-        throw new TekniskException(kode, String.format("Feil %s mot %s", errors.stream().map(GraphQLError::getMessage).collect(joining(",")), uri));
+        throw new TekniskException(kode, String.format("Feil %s mot %s", errors.stream().map(GraphQLError::message).collect(joining(",")), uri));
     }
 
     public static void handleValidationError(String typename, String feilmelding, String aksjon) {

--- a/src/main/java/no/nav/foreldrepenger/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverKlient.java
+++ b/src/main/java/no/nav/foreldrepenger/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverKlient.java
@@ -3,16 +3,13 @@ package no.nav.foreldrepenger.inntektsmelding.integrasjoner.arbeidsgivernotifika
 import static no.nav.foreldrepenger.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonErrorHandler.handleError;
 import static no.nav.foreldrepenger.inntektsmelding.integrasjoner.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonErrorHandler.handleValidationError;
 
-import java.net.http.HttpRequest;
-
 import jakarta.enterprise.context.Dependent;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLRequest;
-import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLResult;
-
+import no.nav.foreldrepenger.graphql.GraphQLRequest;
+import no.nav.foreldrepenger.graphql.GraphQLResult;
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.felles.integrasjon.rest.RestClient;
 import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
@@ -134,7 +131,7 @@ class MinSideArbeidsgiverKlient {
     }
 
     private <T extends GraphQLResult<?>> T query(GraphQLRequest req, Class<T> clazz) {
-        var method = new RestRequest.Method(RestRequest.WebMethod.POST, HttpRequest.BodyPublishers.ofString(req.toHttpJsonBody()));
+        var method = RestRequest.Method.postJson(req.toQueryObject());
         var restRequest = RestRequest.newRequest(method, restConfig.endpoint(), restConfig);
         var response = restKlient.sendReturnUnhandled(restRequest);
         if (LOG.isInfoEnabled()) {

--- a/src/test/java/no/nav/foreldrepenger/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverTjenesteKlientTest.java
+++ b/src/test/java/no/nav/foreldrepenger/inntektsmelding/integrasjoner/arbeidsgivernotifikasjon/MinSideArbeidsgiverTjenesteKlientTest.java
@@ -16,8 +16,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLError;
-import com.kobylynskyi.graphql.codegen.model.graphql.GraphQLErrorType;
+import no.nav.foreldrepenger.graphql.GraphQLError;
+import no.nav.foreldrepenger.graphql.GraphQLErrorType;
 
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.felles.integrasjon.rest.RestClient;


### PR DESCRIPTION
Bruker vår egen Java-generator, siden den vi har brukt ikke har fått noe TLC på 2 år og eier er/var krigsrammet land
NB: Trenger en pluginRepositories i aktuelle repos + at alle oppdaterer lokal settings.xml med det samme.
Alt er testet grundig lokalt med full verdikjede